### PR TITLE
Set useTunnel to true in installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ name: "value-store"
 version: "0.1.0"
 usage: "Store values in DynamoDB"
 ignoreFlags: false
-useTunnel: false
+useTunnel: true
 command: "helm-value-store"
 EOF
 ```


### PR DESCRIPTION
`useTunnel: true` is needed in the `plugin.yaml` in order to communicate with Tiller.