### PR TITLE
Fix chart installation against Tiller 2.4.1

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/skuid/helm-value-store/dynamo"
 	"github.com/skuid/helm-value-store/store"
@@ -78,7 +79,7 @@ func install(cmd *cobra.Command, args []string) {
 	}
 	_, getErr := release.Get()
 
-	if getErr != nil && getErr.Error() != "rpc error: code = 2 desc = release: not found" {
+	if getErr != nil && !strings.Contains(getErr.Error(), "not found") {
 		exitOnErr(err)
 	}
 
@@ -91,7 +92,7 @@ func install(cmd *cobra.Command, args []string) {
 	exitOnErr(err)
 	fmt.Printf("Fetched chart %s to %s\n", release.Chart, dlLocation)
 
-	if getErr != nil && getErr.Error() == "rpc error: code = 2 desc = release: not found" {
+	if getErr != nil && strings.Contains(getErr.Error(), "not found") {
 		// Install
 		fmt.Printf("Installing Release %s\n", release)
 


### PR DESCRIPTION
Chart installation against Tiller 2.4.1 was broken because the error
message returned contained the quoted name of the release being
installed. The previous code checked a very specific error message to
determine if it should install or update. This fix should be backwards
compatable, though I'm sure there's a better way to do it that I don't
see right now.

Example error message returned by `rs.Get` is `rpc error: code = 2 desc = release: "traefik" not found` instead of `rpc error: code = 2 desc = release: not found`.